### PR TITLE
Prepare proper handling of multi dimensional arrays

### DIFF
--- a/extension/helpers.cpp
+++ b/extension/helpers.cpp
@@ -22,57 +22,107 @@ IPluginFunction *GetFunctionByNameEx(IPluginContext *pContext, const char *name)
 	return nullptr;
 }
 
-void PawnVectorToVector(cell_t *vecAddr, Vector &vector) {
+void PawnVectorToVector(cell_t* vecAddr, Vector& vector)
+{
 	vector.x = sp_ctof(vecAddr[0]);
 	vector.y = sp_ctof(vecAddr[1]);
 	vector.z = sp_ctof(vecAddr[2]);
 }
 
-void PawnVectorToVector(cell_t *angAddr, QAngle &angle) {
+void PawnVectorToVector(cell_t* angAddr, QAngle& angle)
+{
 	angle.x = sp_ctof(angAddr[0]);
 	angle.y = sp_ctof(angAddr[1]);
 	angle.z = sp_ctof(angAddr[2]);
 }
 
-void PawnVectorToVector(cell_t *vecAddr, Vector *vector) {
+void PawnVectorToVector(cell_t* vecAddr, Vector* vector)
+{
 	vector->x = sp_ctof(vecAddr[0]);
 	vector->y = sp_ctof(vecAddr[1]);
 	vector->z = sp_ctof(vecAddr[2]);
 }
 
-void PawnVectorToVector(cell_t *angAddr, QAngle *angle) {
+void PawnVectorToVector(cell_t* angAddr, QAngle* angle)
+{
 	angle->x = sp_ctof(angAddr[0]);
 	angle->y = sp_ctof(angAddr[1]);
 	angle->z = sp_ctof(angAddr[2]);
 }
 
-void VectorToPawnVector(cell_t *vecAddr, const Vector vector) {
+void VectorToPawnVector(cell_t* vecAddr, const Vector vector)
+{
 	vecAddr[0] = sp_ftoc(vector.x);
 	vecAddr[1] = sp_ftoc(vector.y);
 	vecAddr[2] = sp_ftoc(vector.z);
 }
 
-void VectorToPawnVector(cell_t *angAddr, const QAngle angle) {
+void VectorToPawnVector(cell_t* angAddr, const QAngle angle)
+{
 	angAddr[0] = sp_ftoc(angle.x);
 	angAddr[1] = sp_ftoc(angle.y);
 	angAddr[2] = sp_ftoc(angle.z);
 }
 
-void VectorToPawnVector(cell_t *vecAddr, const Vector *vector) {
+void VectorToPawnVector(cell_t* vecAddr, const Vector* vector)
+{
 	vecAddr[0] = sp_ftoc(vector->x);
 	vecAddr[1] = sp_ftoc(vector->y);
 	vecAddr[2] = sp_ftoc(vector->z);
 }
 
-void VectorToPawnVector(cell_t *angAddr, const QAngle *angle) {
+void VectorToPawnVector(cell_t* angAddr, const QAngle* angle)
+{
 	angAddr[0] = sp_ftoc(angle->x);
 	angAddr[1] = sp_ftoc(angle->y);
 	angAddr[2] = sp_ftoc(angle->z);
 }
 
-// About double arrays:
+#if SOURCEPAWN_API_VERSION >= 0x0211
+void MatrixToPawnMatrix(IPluginContext* context, cell_t* matAddr, const matrix3x4_t& mat)
+{
+	for ( int r = 0; r < 3; r++ )
+	{
+		cell_t* row = nullptr;
+		if (context->GetRuntime()->UsesDirectArrays())
+		{
+			context->LocalToPhysAddr(matAddr[r], &row);
+		}
+		else
+		{
+			row = (cell_t *)( (uint8_t *)( &matAddr[r] ) + matAddr[r] );
+		}
+
+		for ( int c = 0; c < 4; c++ )
+		{
+			row[c] = sp_ftoc( mat[r][c] );
+		}
+	}
+}
+
+void PawnMatrixToMatrix(IPluginContext* context, cell_t* matAddr, matrix3x4_t& mat)
+{
+	for ( int r = 0; r < 3; r++ )
+	{
+		cell_t* row = nullptr;
+		if (context->GetRuntime()->UsesDirectArrays())
+		{
+			context->LocalToPhysAddr(matAddr[r], &row);
+		}
+		else
+		{
+			row = (cell_t *)( (uint8_t *)( &matAddr[r] ) + matAddr[r] );
+		}
+
+		for ( int c = 0; c < 4; c++ )
+		{
+			mat[r][c] = sp_ctof( row[c] );
+		}
+	}
+}
+#else
 // https://github.com/alliedmodders/sourcemod/blob/b3672916dee4bc6ad4368e31bc6f9b2779b36d79/core/logic/smn_sorting.cpp#L43
-void MatrixToPawnMatrix( cell_t *matAddr, const matrix3x4_t &mat )
+void MatrixToPawnMatrix(IPluginContext* context, cell_t* matAddr, const matrix3x4_t& mat)
 {
 	for ( int r = 0; r < 3; r++ )
 	{
@@ -85,7 +135,7 @@ void MatrixToPawnMatrix( cell_t *matAddr, const matrix3x4_t &mat )
 	}
 }
 
-void PawnMatrixToMatrix( cell_t *matAddr, matrix3x4_t &mat )
+void PawnMatrixToMatrix(IPluginContext* context, cell_t* matAddr, matrix3x4_t& mat)
 {
 	for ( int r = 0; r < 3; r++ )
 	{
@@ -97,6 +147,7 @@ void PawnMatrixToMatrix( cell_t *matAddr, matrix3x4_t &mat )
 		}
 	}
 }
+#endif
 
 const char *HandleErrorToString(HandleError err)
 {

--- a/extension/helpers.h
+++ b/extension/helpers.h
@@ -80,18 +80,23 @@
 		return pContext->ThrowNativeError("Invalid Handle %x (error %i: %s)", hnd, chnderr, HandleErrorToString(chnderr)); \
 	} \
 
-void VectorToPawnVector(cell_t *vecAddr, const Vector vector);
-void VectorToPawnVector(cell_t *vecAddr, const Vector *vector);
-void VectorToPawnVector(cell_t *angAddr, const QAngle angle);
-void VectorToPawnVector(cell_t *angAddr, const QAngle *angle);
+void VectorToPawnVector(cell_t* vecAddr, const Vector vector);
+void VectorToPawnVector(cell_t* vecAddr, const Vector* vector);
+void VectorToPawnVector(cell_t* angAddr, const QAngle angle);
+void VectorToPawnVector(cell_t* angAddr, const QAngle* angle);
 
-void PawnVectorToVector(cell_t *vecAddr, Vector *vector);
-void PawnVectorToVector(cell_t *vecAddr, Vector &vector);
-void PawnVectorToVector(cell_t *angAddr, QAngle *angle);
-void PawnVectorToVector(cell_t *angAddr, QAngle &angle);
+void PawnVectorToVector(cell_t* vecAddr, Vector* vector);
+void PawnVectorToVector(cell_t* vecAddr, Vector& vector);
+void PawnVectorToVector(cell_t* angAddr, QAngle* angle);
+void PawnVectorToVector(cell_t* angAddr, QAngle& angle);
 
-void MatrixToPawnMatrix( cell_t *matAddr, const matrix3x4_t &mat );
-void PawnMatrixToMatrix( cell_t *matAddr, matrix3x4_t &mat );
+#if SOURCEPAWN_API_VERSION >= 0x0211
+void MatrixToPawnMatrix(IPluginContext* context, cell_t* matAddr, const matrix3x4_t& mat);
+void PawnMatrixToMatrix(IPluginContext* context, cell_t* matAddr, matrix3x4_t& mat);
+#else
+void MatrixToPawnMatrix(IPluginContext* context, cell_t* matAddr, const matrix3x4_t& mat);
+void PawnMatrixToMatrix(IPluginContext* context, cell_t* matAddr, matrix3x4_t& mat);
+#endif
 
 const char *HandleErrorToString(HandleError err);
 

--- a/extension/natives/baseanim.h
+++ b/extension/natives/baseanim.h
@@ -49,12 +49,12 @@ CBASEANIMNATIVE(GetAttachmentMatrix)
 	int iAttachment = params[2];
 
 	cell_t * pawnMat;
-	pContext->LocalToPhysAddr( params[3], &pawnMat );
+	pContext->LocalToPhysAddr(params[3], &pawnMat);
 
-	cell_t result = anim->GetAttachment( iAttachment, matrix );
-	if ( result )
+	cell_t result = anim->GetAttachment(iAttachment, matrix);
+	if (result)
 	{
-		MatrixToPawnMatrix( pawnMat, matrix );
+		MatrixToPawnMatrix(pContext, pawnMat, matrix);
 	}
 
 	return result;

--- a/extension/natives/baseent.h
+++ b/extension/natives/baseent.h
@@ -280,9 +280,9 @@ CBASEENTNATIVE(SetModel)
 
 CBASEENTNATIVE(EntityToWorldTransform)
 	cell_t * pawnMat = nullptr;
-	pContext->LocalToPhysAddr( params[2], &pawnMat );
+	pContext->LocalToPhysAddr(params[2], &pawnMat);
 
-	MatrixToPawnMatrix( pawnMat, ent->EntityToWorldTransform() );
+	MatrixToPawnMatrix(pContext, pawnMat, ent->EntityToWorldTransform());
 	return 0;
 }
 

--- a/extension/natives/utilnatives.h
+++ b/extension/natives/utilnatives.h
@@ -3,23 +3,23 @@
 
 #include "helpers.h"
 
-cell_t Util_ConcatTransforms( IPluginContext *pContext, const cell_t *params )
+cell_t Util_ConcatTransforms(IPluginContext* pContext, const cell_t* params)
 {
 	cell_t * inMat1;
 	cell_t * inMat2;
 	cell_t * outMat;
-	pContext->LocalToPhysAddr( params[1], &inMat1 );
-	pContext->LocalToPhysAddr( params[2], &inMat2 );
-	pContext->LocalToPhysAddr( params[3], &outMat );
+	pContext->LocalToPhysAddr(params[1], &inMat1);
+	pContext->LocalToPhysAddr(params[2], &inMat2);
+	pContext->LocalToPhysAddr(params[3], &outMat);
 
 	matrix3x4_t in1;
 	matrix3x4_t in2;
 	matrix3x4_t out;
 
-	PawnMatrixToMatrix( inMat1, in1 );
-	PawnMatrixToMatrix( inMat2, in2 );
-	ConcatTransforms( in1, in2, out );
-	MatrixToPawnMatrix( outMat, out );
+	PawnMatrixToMatrix(pContext, inMat1, in1);
+	PawnMatrixToMatrix(pContext, inMat2, in2);
+	ConcatTransforms(in1, in2, out);
+	MatrixToPawnMatrix(pContext, outMat, out);
 
 	return 0;
 }


### PR DESCRIPTION
As of alliedmodders/sourcepawn@ba26ae3f2b4fbe6e26955655fc1e11981fcaea54 
Plugins compiled on sourcepawn 1.11 will have different 2D arrays. This PR prepares the eventual fix that will be needed for it.

However since SP 1.11 will land with SM 1.11, which has yet to land on stable branch. It would be unwise to update our sourcemod source code installations, just to get access to the new function that was added on `IPluginRuntime`. As this will make the compiled extension only available on SM 1.11.

This is why those preprocessing if statements `#if SOURCEPAWN_API_VERSION >= 0x0211` have been added, so when the time comes, we can provide CBaseNPC builds on SM 1.10 and SM 1.11.
We will remove those statements, once SM 1.12 lands on stable branch, which will probably happen in several years from now.