### PR TITLE
Fix required CI

### DIFF
--- a/.github/workflows/ci-extension.yml
+++ b/.github/workflows/ci-extension.yml
@@ -4,11 +4,6 @@ on:
   workflow_call:
   pull_request:
     branches: [ master ]
-    paths:
-      - 'AMBuildScript'
-      - 'PackageScript'
-      - 'extension/**'
-      - 'extension/**'
 
 jobs:
   build-options:

--- a/.github/workflows/ci-scripting.yml
+++ b/.github/workflows/ci-scripting.yml
@@ -3,11 +3,6 @@ on:
   workflow_call:
   pull_request:
     branches: [ master ]
-    paths:
-      - 'AMBuildScript'
-      - 'PackageScript'
-      - 'scripting/**'
-      - 'scripting/**'
 
 jobs:
   build-options:


### PR DESCRIPTION
A change that was unfortunately overlooked in #41. We've accidentally made the jobs required for PR merge 'optional' this isn't good.