### PR TITLE
Change GetDamageCustom return value

### DIFF
--- a/scripting/include/cbasenpc/takedamageinfo.inc
+++ b/scripting/include/cbasenpc/takedamageinfo.inc
@@ -281,7 +281,7 @@ methodmap CTakeDamageInfo
 	 * @return		Returns the custom damage.
 	 * @error		Invalid takedamageinfo.
 	 */
-	public native float GetDamageCustom();
+	public native int GetDamageCustom();
 
 	/**
 	 * Sets the custom damage.


### PR DESCRIPTION
I'm probably the only that uses this, but using this to check against defined damagecustoms (which does work) produces a warning.